### PR TITLE
Check lore to determine whether (Dis)Enchantable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Added Vanilla Auto Crafter
 * Added Enhanced Auto Crafter
 * Added "Smart-Filling" mode to Cargo Input nodes
+* Added "Netherite Ingot -> Netherite Block" recipe to Electric Press
 
 #### Changes
 * Changed item order in guide for the Villager Rune and Nether Goo (All runes are now grouped together)

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
@@ -292,6 +292,11 @@ final class CargoUtils {
             int maxStackSize = itemInSlot.getType().getMaxStackSize();
             int currentAmount = itemInSlot.getAmount();
 
+            if (!smartFill && currentAmount == maxStackSize) {
+                // Skip full stacks - Performance optimization for non-smartfill nodes
+                continue;
+            }
+
             if (SlimefunUtils.isItemSimilar(itemInSlot, wrapper, true, false)) {
                 if (currentAmount < maxStackSize) {
                     int amount = currentAmount + stack.getAmount();
@@ -339,11 +344,17 @@ final class CargoUtils {
                 inv.setItem(slot, stack);
                 return null;
             } else {
+                int currentAmount = itemInSlot.getAmount();
                 int maxStackSize = itemInSlot.getType().getMaxStackSize();
 
+                if (!smartFill && currentAmount == maxStackSize) {
+                    // Skip full stacks - Performance optimization for non-smartfill nodes
+                    continue;
+                }
+
                 if (SlimefunUtils.isItemSimilar(itemInSlot, wrapper, true, false)) {
-                    if (itemInSlot.getAmount() < maxStackSize) {
-                        int amount = itemInSlot.getAmount() + stack.getAmount();
+                    if (currentAmount < maxStackSize) {
+                        int amount = currentAmount + stack.getAmount();
 
                         if (amount > maxStackSize) {
                             stack.setAmount(amount - maxStackSize);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricPress.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricPress.java
@@ -6,8 +6,10 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
+import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
@@ -70,6 +72,10 @@ public class ElectricPress extends AContainer implements RecipeDisplayItem {
 
         addRecipe(8, new ItemStack(Material.EMERALD, 9), new ItemStack(Material.EMERALD_BLOCK));
         addRecipe(8, new ItemStack(Material.DIAMOND, 9), new ItemStack(Material.DIAMOND_BLOCK));
+
+        if (SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_16)) {
+            addRecipe(16, new ItemStack(Material.NETHERITE_INGOT, 9), new ItemStack(Material.NETHERITE_BLOCK));
+        }
     }
 
     @ParametersAreNonnullByDefault


### PR DESCRIPTION
## Description
Support using lore to prevent enchanting or disenchanting.
The existing config is only for Slimefun items, but this one is mainly for RPG items.
Allow to modify lores in item.yml to facilitate administrator customization.

## Changes
Check lore to determine whether the item is Enchantable/ Disenchantable.
List is supported for config.

## Related Issues
Nothing

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
